### PR TITLE
Support siblings after a group repeater

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -51,9 +51,9 @@ export default function parse(str) {
 				while (node.firstChild) {
 					ctx.appendChild(node.firstChild);
 				}
-				// for convenience, groups can be joined with optional `+` operator
-				stream.eat(OP_SIBLING);
 			}
+			// for convenience, groups can be joined with optional `+` operator
+			stream.eat(OP_SIBLING);
 
 			continue;
 		}


### PR DESCRIPTION
Parsing `(ul>li)*2+span` results in an error.
This is because the sibling operator is not "eaten" after encountering the repeat operator post a group ending

cc @sergeche 