### PR TITLE
Remove group node to avoid extra newline and indent

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,12 +19,19 @@ function unroll(node) {
 		return;
 	}
 
-	for (let i = 1; i < node.repeat.count; i++) {
+	for (let i = 0; i < node.repeat.count; i++) {
 		const clone = node.clone(true);
-		clone.repeat.value = i;
+		clone.repeat.value = i+1;
 		clone.walk(unroll);
-		node.parent.insertBefore(clone, node);
+		if (clone.isGroup) {
+			while (clone.children.length > 0) {
+				clone.firstChild.repeat = clone.repeat;
+				node.parent.insertBefore(clone.firstChild, node);
+			}
+		} else {
+			node.parent.insertBefore(clone, node);
+		}
 	}
-
-	node.repeat.value = node.repeat.count;
+	
+	node.parent.removeChild(node);
 }

--- a/test/parser.js
+++ b/test/parser.js
@@ -32,7 +32,7 @@ describe('Parser', () => {
 	describe('Expand', () => {
 		it('unroll repeated elements', () => {
 			assert.equal(expand('a*2>b*3'), '<a*2@1><b*3@1></b><b*3@2></b><b*3@3></b></a><a*2@2><b*3@1></b><b*3@2></b><b*3@3></b></a>');
-			assert.equal(expand('a>(b+c)*2'), '<a>(<b></b><c></c>)*2@1(<b></b><c></c>)*2@2</a>');
+			assert.equal(expand('a>(b+c)*2'), '<a><b*2@1></b><c*2@1></c><b*2@2></b><c*2@2></c></a>');
 		});
 	});
 });


### PR DESCRIPTION
Grouped abbreviations get expanded with an extra indent and a new line at the beginning
Example: 
`(ul>li)*2` gets expanded to 
```

       <ul>
            <li></li>
       </ul>
       <ul>
            <li></li>
       </ul>
```

instead of 

```
<ul>
     <li></li>
</ul>
<ul>
     <li></li>
</ul>
```

This is due to the group node.
I tried to update the markup-formatter module to ignore the group node.
But it got too messy.
So I propose to fix it in the abbreviation model itself.