### PR TITLE
Fix nested groups

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -28,8 +28,7 @@ export default function parse(str) {
 			// The grouping node should be detached to properly handle
 			// out-of-bounds `^` operator. Node will be attached right on group end
 			const node = new Node();
-			const groupCtx = groupStack.length ? last(groupStack)[0] : ctx;
-			groupStack.push([node, groupCtx, stream.pos]);
+			groupStack.push([node, ctx, stream.pos]);
 			ctx = node;
 			stream.next();
 			continue;

--- a/test/parser.js
+++ b/test/parser.js
@@ -26,6 +26,7 @@ describe('Parser', () => {
 			assert.equal(parse('a>((b>c)(d>e))f'), '<a><b><c></c></b><d><e></e></d><f></f></a>');
 			assert.equal(parse('a>((((b>c))))+d'), '<a><b><c></c></b><d></d></a>');
 			assert.equal(parse('a>(((b>c))*4)+d'), '<a>(<b><c></c></b>)*4<d></d></a>');
+			assert.equal(parse('(div>dl>(dt+dd)*2)'), '<div><dl>(<dt></dt><dd></dd>)*2</dl></div>');
 		});
 	});
 


### PR DESCRIPTION
This PR is to fix the parsing of nested groups.

**Issue**: When parsing nested groups, the inner group gets the outer most node as a parent

Eg: `(div>dl>(dt+dd)*2)` eventually gets expanded to 
```
    <div>
       <dl></dl>
   </div>
   <dt></dt>
   <dd></dd>
   <dt></dt>
   <dd></dd>
```
instead of 
```
    <div>
       <dl>
          <dt></dt>
          <dd></dd>
          <dt></dt>
         <dd></dd>
       </dl>
   </div>

```

cc @sergeche 