### PR TITLE
Apply limit to unrolling elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,13 +4,20 @@ import parse from './lib/parser';
 
 /**
  * Parses given abbreviation and un-rolls it into a full tree: recursively
- * replaces repeated elements with actual nodes
+ * replaces repeated elements with actual nodes until the total number of nodes
+ * reach the given limit.
+ * If no limit is provided, then no limit is applied.
  * @param  {String} abbr
+ * @param  {Number} limit
  * @return {Node}
  */
-export default function(abbr) {
+export default function(abbr, limit) {
 	const tree = parse(abbr);
-	tree.walk(unroll);
+	if (!limit || !Number(limit)) {
+		tree.walk(unroll);
+	} else {
+		unrollNodeUptoLimit(tree, limit);
+	}
 	return tree;
 }
 
@@ -34,4 +41,60 @@ function unroll(node) {
 	}
 	
 	node.parent.removeChild(node);
+}
+
+// Unrolls given node until total number of nodes reach the given limit
+function unrollNodeUptoLimit(node, limit) {
+	if (limit < 0) {
+		return limit;
+	}
+	
+	// Current node is not a repeated node, unroll its children
+	if (!node.repeat || !node.repeat.count) {
+		return unrollChildrenUptoLimit(node, limit);
+	}
+
+	// Curent node is a repeated node. 
+	// Make clones of it, unroll its children and append the clones to the parent.
+	// If Current node is a group, then append its children to the parent instead
+	for (let i = 0; i < node.repeat.count; i++) {
+		if (limit <= 0) {
+			break;
+		}
+
+		const clone = node.clone(true);
+		clone.repeat.value = i+1;
+		limit = unrollChildrenUptoLimit(clone, limit);
+		
+		if (clone.isGroup) {
+			while (clone.children.length > 0) {
+				clone.firstChild.repeat = clone.repeat;
+				node.parent.insertBefore(clone.firstChild, node);
+			}
+		} else {
+			node.parent.insertBefore(clone, node);
+		}
+	}
+	
+	node.parent.removeChild(node);
+	return limit;
+}
+
+// Unrolls children of the node until total number of nodes reach the given limit
+function unrollChildrenUptoLimit(node, limit) {
+	if (!node.isGroup) {
+		limit--;
+	}
+	if (node.children) {
+		// Make a copy of the children before unrolling as more might get added during unrolling
+		var nodeChildren = node.children.slice();
+		for (var i = 0; i < nodeChildren.length; i++) {
+			if (limit > 0) {
+				limit = unrollNodeUptoLimit(nodeChildren[i], limit);
+			} else {
+				node.removeChild(nodeChildren[i]);
+			}
+		}
+	}
+	return limit;
 }

--- a/test/parser.js
+++ b/test/parser.js
@@ -9,6 +9,7 @@ const stringify = require('./assets/stringify').default;
 describe('Parser', () => {
 	const parse = str => stringify(parser(str));
 	const expand = str => stringify(expander(str));
+	const expandWithLimit = (str, limit) => stringify(expander(str, limit));
 
 	describe('Parse', () => {
 		it('basic abbreviations', () => {
@@ -35,5 +36,11 @@ describe('Parser', () => {
 			assert.equal(expand('a*2>b*3'), '<a*2@1><b*3@1></b><b*3@2></b><b*3@3></b></a><a*2@2><b*3@1></b><b*3@2></b><b*3@3></b></a>');
 			assert.equal(expand('a>(b+c)*2'), '<a><b*2@1></b><c*2@1></c><b*2@2></b><c*2@2></c></a>');
 		});
+
+		it('unroll until limit is reached', () => {
+			assert.equal(expandWithLimit('a*10', 2), '<a*10@1></a><a*10@2></a>');
+			assert.equal(expandWithLimit('(a*2)+b*4', 4), '<a*2@1></a><a*2@2></a><b*4@1></b><b*4@2></b>');
+			assert.equal(expandWithLimit('(ul>li)*3+span', 5), '<ul*3@1><li></li></ul><ul*3@2><li></li></ul><ul*3@3></ul>');
+		})
 	});
 });


### PR DESCRIPTION
**Update**: Closing this one in favor of #6. I foolishly used the my master branch as the target branch.

When given abbreviations like say `((span*100)*100)*100`, the parser keeps spinning using up resources. This is bad for editors and users.

This PR applies a limit (upper bound) on the number of nodes that can be unrolled from given abbreviation.

cc @sergeche 