### PR TITLE
Apply limit to unrolling elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,34 +4,70 @@ import parse from './lib/parser';
 
 /**
  * Parses given abbreviation and un-rolls it into a full tree: recursively
- * replaces repeated elements with actual nodes
+ * replaces repeated elements with actual nodes until the total number of nodes
+ * reach the given limit.
+ * If no limit is provided, then no limit is applied.
  * @param  {String} abbr
+ * @param  {Number} limit
  * @return {Node}
  */
-export default function(abbr) {
+export default function (abbr, limit) {
 	const tree = parse(abbr);
-	tree.walk(unroll);
+	limit = { value: limit };
+	tree.walk(node => unroll(node, limit))
 	return tree;
 }
 
-function unroll(node) {
+function unroll(node, guard) {
+	if (guard.value <= 0) {
+		clearNode(node);
+		return false;
+	}
+
 	if (!node.repeat || !node.repeat.count) {
+		if (!node.isGroup) {
+			guard.value--;
+		}
 		return;
 	}
 
 	for (let i = 0; i < node.repeat.count; i++) {
 		const clone = node.clone(true);
 		clone.repeat.value = i+1;
-		clone.walk(unroll);
+		clone.walk(node => unroll(node, guard));
 		if (clone.isGroup) {
 			while (clone.children.length > 0) {
 				clone.firstChild.repeat = clone.repeat;
 				node.parent.insertBefore(clone.firstChild, node);
 			}
 		} else {
+			guard.value--;
 			node.parent.insertBefore(clone, node);
 		}
+
+		if (guard.value <= 0) {
+			clearNode(node);
+			return false;
+		}
 	}
-	
+
 	node.parent.removeChild(node);
+}
+
+// Remove node, it's children and siblings that come after it.
+function clearNode(nodeToClear) {
+	if (!nodeToClear) {
+		return;
+	}
+	nodeToClear.children = [];
+	if (!nodeToClear.parent) {
+		return;
+	}
+	var next = nodeToClear.nextSibling;
+	while (next) {
+		var temp = next.nextSibling;
+		nodeToClear.parent.removeChild(next);
+		next = temp;
+	}
+	nodeToClear.parent.removeChild(nodeToClear);
 }

--- a/test/parser.js
+++ b/test/parser.js
@@ -9,6 +9,7 @@ const stringify = require('./assets/stringify').default;
 describe('Parser', () => {
 	const parse = str => stringify(parser(str));
 	const expand = str => stringify(expander(str));
+	const expandWithLimit = (str, limit) => stringify(expander(str, limit));
 
 	describe('Parse', () => {
 		it('basic abbreviations', () => {
@@ -35,5 +36,13 @@ describe('Parser', () => {
 			assert.equal(expand('a*2>b*3'), '<a*2@1><b*3@1></b><b*3@2></b><b*3@3></b></a><a*2@2><b*3@1></b><b*3@2></b><b*3@3></b></a>');
 			assert.equal(expand('a>(b+c)*2'), '<a><b*2@1></b><c*2@1></c><b*2@2></b><c*2@2></c></a>');
 		});
+
+		it('unroll until limit is reached', () => {
+			assert.equal(expandWithLimit('a*10', 2), '<a*10@1></a><a*10@2></a>');
+			assert.equal(expandWithLimit('(ul>li)*3+span', 5), '<ul*3@1><li></li></ul><ul*3@2><li></li></ul><ul*3@3></ul>');
+			assert.equal(expandWithLimit('a+b+c+d+e+f+g+h+i+j', 5), '<a></a><b></b><c></c><d></d><e></e>');
+			assert.equal(expandWithLimit('a*2+b*6',5), '<a*2@1></a><a*2@2></a><b*6@1></b><b*6@2></b><b*6@3></b>');
+			assert.equal(expandWithLimit('a>b>c>d>e>f>g', 5), '<a><b><c><d><e></e></d></c></b></a>');
+		})
 	});
 });


### PR DESCRIPTION
When given abbreviations like say `((span*100)*100)*100`, the parser keeps spinning using up resources. This is bad for editors and users.

This PR provides an option to apply a limit (upper bound) on the number of nodes that can be unrolled from given abbreviation.

cc @sergeche 