### PR TITLE
Allow square brackets around attribute names

### DIFF
--- a/lib/attribute.js
+++ b/lib/attribute.js
@@ -10,7 +10,7 @@ const EQUALS     = 61; // =
 const ATTR_OPEN  = 91; // [
 const ATTR_CLOSE = 93; // ]
 
-const reAttributeName = /^\!?[\w\-:\$@]+\.?$/;
+const reAttributeName = /^\!?[\w\-:\$@]+\.?$|^\!?\[[\w\-:\$@]+\]\.?$/;
 
 /**
  * Consumes attributes defined in square braces from given stream.
@@ -41,6 +41,13 @@ export default function(stream) {
 		} else if (eatUnquoted(stream)) {
 			// Consumed next word: could be either attribute name or unquoted default value
 			token = stream.current();
+
+			// In angular attribute names can be surrounded by []
+			if (token[0] === '[' && stream.peek() === ATTR_CLOSE) {
+				stream.next();
+				token = stream.current();
+			}
+			
 			if (!reAttributeName.test(token)) {
 				// anonymous attribute
 				result.push({ name: null, value: token });
@@ -112,5 +119,5 @@ function eatUnquoted(stream) {
 
 function isUnquoted(code) {
 	return !isSpace(code) && !isQuote(code)
-		&& code !== ATTR_OPEN && code !== ATTR_CLOSE && code !== EQUALS;
+		 && code !== ATTR_CLOSE && code !== EQUALS;
 }

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -12,11 +12,12 @@ describe('Attributes', () => {
 		let attrs = parse('[a]');
 		assert.deepEqual(parse('[a]'), [{name: 'a'}]);
 
-		attrs = parse('[a b c]');
-		assert.equal(attrs.length, 3);
+		attrs = parse('[a b c [d]]');
+		assert.equal(attrs.length, 4);
 		assert.deepEqual(attrs[0], {name: 'a'});
 		assert.deepEqual(attrs[1], {name: 'b'});
 		assert.deepEqual(attrs[2], {name: 'c'});
+		assert.deepEqual(attrs[3], {name: '[d]'});
 	});
 
 	it('unquoted values', () => {
@@ -34,6 +35,10 @@ describe('Attributes', () => {
 		assert.equal(attrs.length, 2);
 		assert.deepEqual(attrs[0], {name: 'a', value: 'b.c'});
 		assert.deepEqual(attrs[1], {name: 'd', value: 'тест'});
+
+		attrs = parse('[[a]=b]');
+		assert.equal(attrs.length, 1);
+		assert.deepEqual(attrs[0], {name: '[a]', value: 'b'});
 	});
 
 	it('with quoted values', () => {
@@ -46,6 +51,10 @@ describe('Attributes', () => {
 		assert.deepEqual(attrs[0], {name: 'a', value: 'b'});
 		assert.deepEqual(attrs[1], {name: 'c', value: 'd'});
 		assert.deepEqual(attrs[2], {name: 'e', value: ''});
+
+		attrs = parse('[[a]="b"]');
+		assert.equal(attrs.length, 1);
+		assert.deepEqual(attrs[0], {name: '[a]', value: 'b'});
 	});
 
 	it('mixed quotes', () => {


### PR DESCRIPTION
From https://github.com/Microsoft/vscode/issues/32986

`li>a[routerLinkActive="active" [routerLink]="['/applications']"]`
is expected to expand to 
```
<li>
    <a href="" routerLinkActive="active" [routerLink]="/applications"></a>
</li>
```

But parsing of such abbreviations fails as the current parser doesn't allow `[` or `]` in attribute name.

This PR fixes the issue by allowing attribute names to start with `[` and end with `]`

Logged https://github.com/emmetio/abbreviation/issues/11 for tracking this bug in this repo

cc @sergeche 
